### PR TITLE
商品一覧表示機能(herokuにプッシュ時のエラー解消)

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
 
 
   def index
-    @items = Item.all.oder(id: "DESC")
+    @items = Item.all.order(id: "DESC")
   end
 
   def new


### PR DESCRIPTION
レビュー後の修正
※herokuにプッシュ時に『We're sorry, but something went wrong.』のエラー
ログを確認すると、oder→order
の記述間違いだった。